### PR TITLE
feat: show error details for response type mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kapeta/resource-type-rest",
-    "version": "local",
+    "version": "0.0.0-local",
     "description": "Provides REST API and Client resource type to Kapeta",
     "keywords": [
         "kapeta",

--- a/src/web/mapping/APIToClientMapper.tsx
+++ b/src/web/mapping/APIToClientMapper.tsx
@@ -8,7 +8,7 @@ import type { RESTResource, RESTResourceSpec } from '../types';
 import type { DSLControllerMethod, MappedMethod } from './types';
 import { ItemTypes } from './types';
 import { ConnectionMethodsMapping, ResourceTypeProviderMappingProps } from '@kapeta/ui-web-types';
-import { DnDContainer, DnDDrag, DnDDrop, FormReadyHandler } from '@kapeta/ui-web-components';
+import { DnDContainer, DnDDrag, DnDDrop, FormReadyHandler, Tooltip } from '@kapeta/ui-web-components';
 import RestMethodView from '../RestMethodView';
 import { toRESTKindContext } from '../types';
 import { useMappingHandlerBuilder } from './useMappingHandlerBuilder';
@@ -186,7 +186,25 @@ const APIToClientMapper: React.FC<RestResourceToClientMapperProps> = ({
                                         )}
 
                                         {!method.source && method.target && (
-                                            <i title={'Missing mapping'} className={'fas fa-exclamation-triangle'} />
+                                            <Tooltip
+                                                title={
+                                                    method.errors ? (
+                                                        <>
+                                                            <p>Mapping errors found:</p>
+                                                            <ul style={{ marginLeft: 0, paddingLeft: '1em' }}>
+                                                                {method.errors.map((m) => (
+                                                                    <p key={m}>{m}</p>
+                                                                ))}
+                                                            </ul>
+                                                        </>
+                                                    ) : null
+                                                }
+                                            >
+                                                <i
+                                                    title={'Missing mapping'}
+                                                    className={'fas fa-exclamation-triangle'}
+                                                />
+                                            </Tooltip>
                                         )}
                                     </div>
                                     <div className={'target'}>

--- a/src/web/mapping/types.ts
+++ b/src/web/mapping/types.ts
@@ -47,6 +47,7 @@ export interface MappedMethod {
     target?: MappedMethodInfo;
     mapped: boolean;
     mapping?: Mapping[];
+    errors?: string[];
 }
 
 export interface MappedMethodInfo extends DSLControllerMethod {
@@ -70,30 +71,37 @@ export type MappingHandlerData = {
     data: ConnectionMethodsMapping;
 };
 
-export function createEqualMapping(sourceMethod: MappedMethodInfo, targetMethod: MappedMethodInfo): MappedMethod {
+export function createEqualMapping(
+    sourceMethod: MappedMethodInfo,
+    targetMethod: MappedMethodInfo,
+    errors?: string[]
+): MappedMethod {
     return {
         sourceId: toId(sourceMethod),
         source: sourceMethod,
         targetId: toId(targetMethod),
         target: targetMethod,
         mapped: true,
+        errors,
     };
 }
 
-export function createTargetOnlyMapping(method: DSLControllerMethod): MappedMethod {
+export function createTargetOnlyMapping(method: DSLControllerMethod, errors?: string[]): MappedMethod {
     return {
         targetId: toId(method),
         target: method,
         mapped: false,
         mapping: [],
+        errors,
     };
 }
 
-export function createSourceOnlyMapping(method: DSLControllerMethod) {
+export function createSourceOnlyMapping(method: DSLControllerMethod, errors?: string[]) {
     return {
         sourceId: toId(method),
         source: method,
         mapped: false,
         mapping: [],
+        errors,
     };
 }

--- a/src/web/mapping/useMappingHandlerBuilder.ts
+++ b/src/web/mapping/useMappingHandlerBuilder.ts
@@ -5,7 +5,7 @@
 
 import { useEffect, useReducer } from 'react';
 import { useMappingHandler } from './useMappingHandler';
-import { RESTKindContext, getCompatibleRESTMethodsIssues, isCompatibleRESTMethods } from '../types';
+import { RESTKindContext, getCompatibleRESTMethodsIssues } from '../types';
 import {
     MappedMethod,
     MappingHandlerContext,

--- a/src/web/mapping/useMappingHandlerBuilder.ts
+++ b/src/web/mapping/useMappingHandlerBuilder.ts
@@ -5,7 +5,7 @@
 
 import { useEffect, useReducer } from 'react';
 import { useMappingHandler } from './useMappingHandler';
-import { RESTKindContext, isCompatibleRESTMethods } from '../types';
+import { RESTKindContext, getCompatibleRESTMethodsIssues, isCompatibleRESTMethods } from '../types';
 import {
     MappedMethod,
     MappingHandlerContext,
@@ -258,10 +258,11 @@ function reducer(state: MappingBuilderState, action: ActionType): MappingBuilder
                 mappedTargets.push(targetMethod);
                 mappedSources.push(sourceMethod);
 
-                const isCompatible = isCompatibleRESTMethods(
+                const issues = getCompatibleRESTMethodsIssues(
                     { method: sourceMethod, entities: state.sourceContext.entities },
                     { method: targetMethod, entities: state.targetContext.entities }
                 );
+                const isCompatible = issues.length === 0;
 
                 if (!isCompatible) {
                     // Something changed and methods are no longer compatible
@@ -269,7 +270,10 @@ function reducer(state: MappingBuilderState, action: ActionType): MappingBuilder
                         `Mapping for ${handlerContextClone.sourceName}.${sourceMethodId} and ${handlerContextClone.targetName}.${mapping.targetId} was invalid and was removed.`
                     );
 
-                    mappedMethods.push(createSourceOnlyMapping(sourceMethod), createTargetOnlyMapping(targetMethod));
+                    mappedMethods.push(
+                        createSourceOnlyMapping(sourceMethod, issues),
+                        createTargetOnlyMapping(targetMethod, issues)
+                    );
                     return;
                 }
 

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -59,12 +59,12 @@ export function getCompatibleRESTMethodsIssues(aContext: RESTMethodContext, bCon
     }
 
     if (!aArgs || !bArgs) {
-        errors.push('Argument counts is not compatible');
+        errors.push('Argument counts must be equal');
         return errors;
     }
 
     if (aArgs.length !== bArgs.length) {
-        errors.push('Argument counts is not compatible');
+        errors.push('Argument counts must be equal');
         return errors;
     }
 

--- a/src/web/types.ts
+++ b/src/web/types.ts
@@ -40,8 +40,15 @@ export function getCompatibleRESTMethodsIssues(aContext: RESTMethodContext, bCon
     const errors = [];
     const a = aContext.method;
     const b = bContext.method;
-    if (!DSLCompatibilityHelper.isCompatible(a.returnType, b.returnType, aContext.entities, bContext.entities)) {
+    const returnTypeIssues = DSLCompatibilityHelper.getIssuesForTypes(
+        a.returnType,
+        b.returnType,
+        aContext.entities,
+        bContext.entities
+    );
+    if (returnTypeIssues.length > 0) {
         errors.push('Response types are not compatible');
+        errors.push(...returnTypeIssues);
     }
 
     const aArgs = a.parameters;

--- a/test/Types.test.ts
+++ b/test/Types.test.ts
@@ -38,14 +38,7 @@ describe('Types', () => {
                     makeEditContext('test1', [], 'void'),
                     makeEditContext('test2', [], 'string')
                 )
-            ).toEqual(['Response types are not compatible']);
-
-            expect(
-                getCompatibleRESTMethodsIssues(
-                    makeEditContext('test1', [], 'void'),
-                    makeEditContext('test2', [], 'string')
-                )
-            ).toEqual(['Response types are not compatible']);
+            ).toEqual(['Response types are not compatible', 'Types are not both void']);
 
             expect(isCompatibleRESTMethods(makeEditContext('test1', [], 'string'), makeEditContext('test2', []))).toBe(
                 false
@@ -59,7 +52,6 @@ describe('Types', () => {
                 isCompatibleRESTMethods(makeEditContext('test1', [], 'string'), makeEditContext('test2', [], 'string'))
             ).toBe(true);
         });
-
 
         test('arguments with same entity name but different structure does not match', () => {
             expect(
@@ -119,7 +111,7 @@ describe('Types', () => {
                     makeEditContext('test1', [], 'User', ENTITIES),
                     makeEditContext('test2', [], 'User', ENTITIES_ALT)
                 )
-            ).toEqual(['Response types are not compatible']);
+            ).toEqual(['Response types are not compatible', 'Property not found: id']);
         });
 
         test('response type with same entity name and structure does match', () => {


### PR DESCRIPTION
Adds tooltips to connection errors, with list of issues.

Response type issues:

<img width="1062" alt="Screenshot 2024-04-08 at 15 58 14" src="https://github.com/kapetacom/provider-resource-internal-rest/assets/296057/2ef24b90-1f25-4125-b90c-7dc51130b3ee">
